### PR TITLE
ci: repair dependabot config, harden release workflow, bump HIGH-advisory lockfiles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,47 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
+# Dependabot version updates.
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
+#
+# One entry per manifest location. The previous config declared an empty
+# package-ecosystem at the repo root, which matches no ecosystem, so no update
+# PRs were ever opened and the runner and website lockfiles drifted behind
+# their advisories.
+#
+# cooldown holds a PR until a release has been public for a week, which
+# narrows the window in which a compromised release gets merged automatically.
 
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "cargo"
+    directory: "/runner"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "npm"
+    directory: "/website"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "npm"
+    directory: "/npm"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "swift"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/runner-release.yml
+++ b/.github/workflows/runner-release.yml
@@ -47,11 +47,13 @@ jobs:
       - name: Bump version in runner/Cargo.toml
         id: bump
         working-directory: runner
+        env:
+          BUMP: ${{ inputs.bump }}
         run: |
           set -euo pipefail
           CURRENT=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
           IFS='.' read -r major minor patch <<< "$CURRENT"
-          case "${{ inputs.bump }}" in
+          case "$BUMP" in
             major) major=$((major + 1)); minor=0; patch=0 ;;
             minor) minor=$((minor + 1)); patch=0 ;;
             patch) patch=$((patch + 1)) ;;

--- a/runner/Cargo.lock
+++ b/runner/Cargo.lock
@@ -849,9 +849,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -2606,9 +2606,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -3492,9 +3492,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -3715,9 +3715,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -3734,7 +3734,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -4197,9 +4197,9 @@
       }
     },
     "node_modules/svgo": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
-      "integrity": "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
+      "integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
       "license": "MIT",
       "dependencies": {
         "commander": "^11.1.0",


### PR DESCRIPTION
Found while scanning the repo before installing it. Three related issues, smallest first.

**1. Dependabot has never run.** `.github/dependabot.yml` is still the GitHub starter template — one entry with `package-ecosystem: ""` at the repo root. An empty ecosystem matches no manifest, so no update PR has ever been opened. This is the root cause of 2, and it is why nothing flagged them.

Replaced with one entry per manifest location: cargo `/runner`, npm `/website`, npm `/npm`, github-actions, swift. Each gets `cooldown: default-days: 7`, so a freshly published release is not proposed the instant it lands.

**2. HIGH advisories in committed lockfiles.**

- `runner/Cargo.lock`: quinn-proto 0.11.14 → 0.11.15 (GHSA-4w2j-m93h-cj5j)
- `website/package-lock.json`: js-yaml, nanoid, postcss, svgo — via `npm audit fix --package-lock-only`, so no install scripts ran

Not fixed here: sharp 0.34.5 (GHSA-f88m-g3jw-g9cj) only resolves through astro 6 → 7.2.2, a breaking major on the docs site. That deserves its own PR.

**3. Shell injection surface in `runner-release.yml`.** `${{ inputs.bump }}` was interpolated straight into the `run:` block, so the shell sees the expansion before it sees the script. The `choice` input type constrains it today; the pattern breaks the moment that changes. Now passed through `env:` and read as `"$BUMP"`.

Verification: Trivy HIGH/CRITICAL 8 → 1 (the remaining one is sharp). Semgrep `p/default` ERRORs 3 → 2 (the remaining two are `curl | sh` for Ollama's own installer in CI).

Left alone deliberately: 60 mutable action tags (`@v4` style). SHA-pinning is the right fix, but the `github-actions` Dependabot entry added here is the prerequisite — worth a follow-up rather than a 60-line diff bundled into this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
